### PR TITLE
Fix SecureBoot status check for Bash script

### DIFF
--- a/Bash/BootHoleDetection.sh
+++ b/Bash/BootHoleDetection.sh
@@ -393,8 +393,9 @@ sb_failed=0
 
 check_secure_boot() {
     state=$(mokutil --sb-state 2>&1);
+    mokutil_status=$?
     printf "[*] mokutil:\n%s\n\n" "$state"
-    if [ $? -ne 0 ]; then
+    if [ $mokutil_status -ne 0 ]; then
         echo [-] mokutil returned non-zero status: exiting
         exit 1
     fi

--- a/Bash/BootHoleDetection.sh
+++ b/Bash/BootHoleDetection.sh
@@ -392,7 +392,13 @@ vuln=0
 sb_failed=0
 
 check_secure_boot() {
-    mokutil --sb-state | grep -qs 'SecureBoot disabled'
+    state=$(mokutil --sb-state 2>&1);
+    printf "[*] mokutil:\n%s\n\n" "$state"
+    if [ $? -ne 0 ]; then
+        echo [-] mokutil returned non-zero status: exiting
+        exit 1
+    fi
+    echo $state | grep -qs 'SecureBoot enabled'
 }
 
 check_cert() {
@@ -417,10 +423,8 @@ check_hash() {
 }
 
 # Check if SecureBoot is enabled
-if check_secure_boot; then
-    echo -e "[!] SecureBoot is disabled: ESP not protected\n"
-else
-    echo -e "[+] SecureBoot is enabled\n"
+if ! check_secure_boot; then
+    echo -e "[!] ESP is not protected\n"
 fi
 
 # Attempt to mount efi partition if not available


### PR DESCRIPTION
Check if system supports SecureBoot by testing mokutil return code.

Fix for #2 and SecureBoot status contradiction in #3 .